### PR TITLE
Fix: Add check for `priv_dir` existance

### DIFF
--- a/lib/mix/tasks/compile.phoenix_sass.ex
+++ b/lib/mix/tasks/compile.phoenix_sass.ex
@@ -22,6 +22,9 @@ defmodule Mix.Tasks.Compile.PhoenixSass do
     |> Path.join(config()[:pattern])
     |> process_patterns()
     |> check_result()
+  catch
+    {:error, msg} ->
+      Logger.error("#{app()}: #{msg}")
   end
 
   defp process_patterns(pattern) when not is_list(pattern),
@@ -147,9 +150,19 @@ defmodule Mix.Tasks.Compile.PhoenixSass do
     do: Mix.Project.config[:app]
 
   defp priv_dir() do
-    app()
-    |> :code.priv_dir()
-    |> String.Chars.to_string()
+    path =
+      Mix.Project.app_path()
+      |> Path.join("priv")
+
+    path
+    |> Path.expand()
+    |> File.exists?()
+    |> case do
+         true ->
+           path
+         false ->
+           throw {:error, "priv_dir path invalid or inaccessible: #{path}"}
+       end
   end
 
   defp config do


### PR DESCRIPTION
## Changes
- revert to `Mix.Project.app_path/1` instead of `:code.priv/1`
- add check for priv_dir existance, show error when inaccessible

Resolves #7 